### PR TITLE
Add xyz parser

### DIFF
--- a/pengwann/geometry.py
+++ b/pengwann/geometry.py
@@ -26,8 +26,9 @@ from __future__ import annotations
 import numpy as np
 from collections.abc import Sequence
 from numpy.typing import ArrayLike, NDArray
+from pengwann.io import read_xyz
 from pengwann.utils import get_atom_indices, integrate_descriptor
-from pymatgen.core import Lattice, Molecule, Structure
+from pymatgen.core import Lattice, Structure
 from typing import NamedTuple
 
 
@@ -299,16 +300,9 @@ def build_geometry(path: str, cell: ArrayLike) -> Structure:
     """
     lattice = Lattice(cell)
 
-    xyz = Molecule.from_file(path)
+    symbols, coords = read_xyz(path)
 
-    assert xyz is not None
-    species, coords = [], []
-    for site in xyz:
-        symbol = site.species_string.capitalize()
-        species.append(symbol)
-        coords.append(site.coords)
-
-    geometry = Structure(lattice, species, coords, coords_are_cartesian=True)
+    geometry = Structure(lattice, symbols, coords, coords_are_cartesian=True)
 
     assign_wannier_centres(geometry)
 

--- a/pengwann/io.py
+++ b/pengwann/io.py
@@ -205,3 +205,38 @@ def read_hamiltonian(path: str) -> dict[tuple[int, ...], NDArray[np.complex128]]
         h[bl][m, n] = complex(real, imaginary)
 
     return h
+
+
+def read_xyz(path: str) -> tuple[list[str], list[tuple[float, ...]]]:
+    """
+    Parse the symbols and coordinates from a Wannier90 seedname_centres.xyz file.
+
+    Parameters
+    ----------
+    path : str
+        The filepath to seedname_centres.xyz
+
+    Returns
+    -------
+    symbols : list[str]
+        The elemental symbol for each Wannier centre or atom in the xyz file.
+
+    coords : list[tuple[float, ...]]:
+        The coordinates for each Wannier centre or atom in the xyz file.
+    """
+    with open(path, "r") as stream:
+        lines = stream.readlines()
+
+    start_idx = 2
+
+    symbols, coords = [], []
+    for line in lines[start_idx:]:
+        data = line.split()
+
+        symbol = str(data[0]).capitalize()
+        cart_coords = tuple(float(coord) for coord in data[1:])
+
+        symbols.append(symbol)
+        coords.append(cart_coords)
+
+    return symbols, coords


### PR DESCRIPTION
Closes #14 

The previous logic of the `build_geometry` function was causing problems when the seedname_centres.xyz file generated by Wannier90 contained lowercase elemental symbols.

To fix this I have added a simple xyz parser and removed the dependence on `Molecule`. Unfortunately #12 still stands because I have yet to implement the necessary linear algebra for locating the closest images of each Wannier centre to a given atom.