### PR TITLE
Add error handling if unable to determine # CPU cores for parallelisation

### DIFF
--- a/src/pengwann/descriptors.py
+++ b/src/pengwann/descriptors.py
@@ -695,8 +695,12 @@ class DescriptorCalculator:
                 )
             )
 
-        max_proc = cpu_count()
-        processes = min(max_proc, num_proc)
+        try:
+            max_proc = cpu_count()
+            processes = min(max_proc, num_proc)
+
+        except NotImplementedError:
+            processes = num_proc
 
         with Pool(processes=processes) as pool:
             if show_progress:


### PR DESCRIPTION
The `cpu_count` function of the `multiprocessing` module raises a `NotImplementedError` if the number of CPU cores cannot be determined - this is currently not accounted for.

This PR adds a simple `try/except` so that the number of processes launched in parallel can always fall back on the user-supplied `num_proc` argument.