### PR TITLE
Explicitly highlight local execution of example notebooks

### DIFF
--- a/.github/workflows/build-t2.yml
+++ b/.github/workflows/build-t2.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: 3.x
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1.48.0
+        uses: PyO3/maturin-action@v1.47.3
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
@@ -68,7 +68,7 @@ jobs:
           python-version: 3.x
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1.48.0
+        uses: PyO3/maturin-action@v1.47.3
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/build-t2.yml
+++ b/.github/workflows/build-t2.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: 3.x
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.48.0
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
@@ -68,7 +68,7 @@ jobs:
           python-version: 3.x
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.48.0
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/.github/workflows/build-t2.yml
+++ b/.github/workflows/build-t2.yml
@@ -10,8 +10,6 @@ jobs:
       matrix:
         platform:
           - runner: ubuntu-latest
-            target: x86
-          - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
@@ -30,11 +28,43 @@ jobs:
           python-version: 3.x
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1.47.3
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: auto
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ runner.os }}-${{ matrix.platform.target }}
+          path: dist
+
+  # separate job for x86 as sccache>=0.10.0 currently not possible
+  linux-glibc-x86:
+    name: 🐧 linux - 🧬 ${{ matrix.platform.target }} - 🐃 glibc
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
           manylinux: auto
 
       - name: Upload wheels
@@ -68,7 +98,7 @@ jobs:
           python-version: 3.x
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1.47.3
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For more details regarding installation and platform support, see the full [inst
 
 For a quick run through of the basics, see the first example in the docs on [computing bonding descriptors in diamond](https://pengwann.readthedocs.io/en/latest/examples/diamond/basics.html).
 
+All of the [examples](https://pengwann.readthedocs.io/en/latest/examples.html) discussed in the documentation are also available for local execution if desired under [docs/examples](docs/examples).
+
 ## Support 🤝
 
 ### Getting help 👋

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For more details regarding installation and platform support, see the full [inst
 
 For a quick run through of the basics, see the first example in the docs on [computing bonding descriptors in diamond](https://pengwann.readthedocs.io/en/latest/examples/diamond/basics.html).
 
-All of the [examples](https://pengwann.readthedocs.io/en/latest/examples.html) discussed in the documentation are also available for local execution if desired under [docs/examples](https://github.com/PatrickJTaylor/pengWann/blob/main/docs/examples).
+All of the [example notebooks](https://pengwann.readthedocs.io/en/latest/examples.html) discussed in the documentation are also available for local execution under [docs/examples](https://github.com/PatrickJTaylor/pengWann/blob/main/docs/examples) should you wish to play around with some sample workflows and their associated data.
 
 ## Support 🤝
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For more details regarding installation and platform support, see the full [inst
 
 For a quick run through of the basics, see the first example in the docs on [computing bonding descriptors in diamond](https://pengwann.readthedocs.io/en/latest/examples/diamond/basics.html).
 
-All of the [examples](https://pengwann.readthedocs.io/en/latest/examples.html) discussed in the documentation are also available for local execution if desired under [docs/examples](docs/examples).
+All of the [examples](https://pengwann.readthedocs.io/en/latest/examples.html) discussed in the documentation are also available for local execution if desired under [docs/examples](https://github.com/PatrickJTaylor/pengWann/blob/main/docs/examples).
 
 ## Support 🤝
 


### PR DESCRIPTION
Adds a small paragraph to the README to point out that the example notebooks in the documentation can also be executed and played around with locally.

Thanks to @LIVazquezS for highlighting this gap in the docs as part of the ongoing JOSS review openjournals/joss-reviews#7890!