### PR TITLE
Manually add LICENSE to maturin sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ homepage = 'https://github.com/PatrickJTaylor/pengWann'
 [tool.maturin]
 features = ['pyo3/extension-module']
 module-name = 'pengwann._geometry'
+include = [{ path = "LICENSE", format = "sdist"}]
 
 [tool.ruff]
 extend-exclude = ['*.ipynb']


### PR DESCRIPTION
I have just discovered that the sdist generated by maturin currently does not include the LICENSE file.

This is a trivial config change to manually include the LICENSE.

Possible duplicate of PyO3/maturin#2531.