### PR TITLE
Add support for installation with conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ The latest tagged release of `pengwann` is `pip`-installable as:
 pip install pengwann
 ```
 
+Similarly, if you are using a `conda` environment, the latest tagged release is `conda`-installable as:
+
+```shell
+conda install -c conda-forge pengwann
+```
+
 Alternatively, to install the current development build, you can build from source with:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Requires Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue?logo=python&logoColor=white&logoSize=auto)](https://python.org/downloads)
 [![Requires Rust 1.82.0+](https://img.shields.io/badge/Rust-1.82.0%2B-blue?logo=rust&logoColor=white&logoSize=auto)](https://rustup.rs/)
 [![PyPI version](https://img.shields.io/pypi/v/pengWann?label=PyPI)](https://pypi.org/project/pengwann/)
+[![Conda version](https://img.shields.io/conda/vn/conda-forge/pengwann?logo=anaconda&logoColor=white&logoSize=auto)](https://anaconda.org/conda-forge/pengwann)
 
 A lightweight Python package for computing descriptors of chemical bonding and local electronic structure from Wannier functions.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@
 [![Requires Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue?logo=python&logoColor=white&logoSize=auto)](https://python.org/downloads)
 [![Requires Rust 1.82.0+](https://img.shields.io/badge/Rust-1.82.0%2B-blue?logo=rust&logoColor=white&logoSize=auto)](https://rustup.rs/)
 [![PyPI version](https://img.shields.io/pypi/v/pengWann?label=PyPI)](https://pypi.org/project/pengwann/)
+[![Conda version](https://img.shields.io/conda/vn/conda-forge/pengwann?logo=anaconda&logoColor=white&logoSize=auto)](https://anaconda.org/conda-forge/pengwann)
 
 `pengwann` is a lightweight Python package for calculating descriptors of chemical bonding and local electronic structure from Wannier functions (as obtained from [Wannier90](https://wannier.org/)).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,9 +1,15 @@
 # Installation
 
-To install the most recent tagged release of `pengwann`, use `pip`:
+To install the most recent tagged release of `pengwann`, use `pip` or `conda`:
 
 ```shell
 pip install pengwann
+```
+
+or
+
+```shell
+conda install -c conda-forge pengwann
 ```
 
 Alternatively, if you would like to install the bleeding-edge latest version of the code (i.e. the current Git commit), you can build from source with:


### PR DESCRIPTION
Adds installation instructions for `conda` users, having contributed a recipe to conda-forge in conda-forge/staged-recipes#29675.

Linking openjournals/joss-reviews#7890 as this addition was suggested as part of the ongoing JOSS review.