### PR TITLE
Build/test for 3.14 on Windows/MacOS

### DIFF
--- a/.github/workflows/build-t1.yml
+++ b/.github/workflows/build-t1.yml
@@ -53,6 +53,7 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -91,6 +92,7 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-t1.yml
+++ b/.github/workflows/build-t1.yml
@@ -53,7 +53,7 @@ jobs:
             3.11
             3.12
             3.13
-            3.14
+            3.14-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -92,7 +92,7 @@ jobs:
             3.11
             3.12
             3.13
-            3.14
+            3.14-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-t2.yml
+++ b/.github/workflows/build-t2.yml
@@ -117,7 +117,7 @@ jobs:
             3.11
             3.12
             3.13
-            3.14
+            3.14-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-t2.yml
+++ b/.github/workflows/build-t2.yml
@@ -117,6 +117,7 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14-dev"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         platform:
           - runner: ubuntu-latest
             target: x86_64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         platform:
           - runner: ubuntu-latest
             target: x86_64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14-dev"]
         platform:
           - runner: ubuntu-latest
             target: x86_64


### PR DESCRIPTION
`conda-forge` are pushing for `3.14` adoption - this is a necessary step towards that (manylinux takes care of itself, but I need to explicitly test and build for `3.14` on Windows/MacOS).